### PR TITLE
Updated SD score and formatting.

### DIFF
--- a/ghostwriter/modules/custom_serializers.py
+++ b/ghostwriter/modules/custom_serializers.py
@@ -918,7 +918,17 @@ class ReportDataSerializer(CustomModelSerializer):
             ("physical", findings_score_total, 64.30909091, 56.55371468),
         ]
         for d in score_type_data:
-            rep["totals"]["sd_score_" + d[0]] = _get_score(d[1], d[2], d[3])
+            mean = d[2]
+            std = d[3]
+            best_score = _get_score(0, mean, std)
+            score = _get_score(d[1], mean, std)
+
+            # Convert the score to a percentage based on the range of the SD graph max value (3 STD)
+            # Negatives we are graphing as a score whereas positive as a percentage
+            # since we don't know the worst score but do know the best score
+            if score > 0:
+                score = score / best_score * 3
+            rep["totals"]["sd_score_" + d[0]] = score
 
         # Calculate the findings chart data variable
         def _get_chart_data(findings):

--- a/ghostwriter/modules/reportwriter.py
+++ b/ghostwriter/modules/reportwriter.py
@@ -714,6 +714,11 @@ class Reportwriter:
                 else:
                     par.alignment = WD_ALIGN_PARAGRAPH.CENTER
                     run = par.add_run()
+
+                    # Add a +1 space point before the image to not overlap onto the table header
+                    f = par.paragraph_format
+                    f.space_before = Pt(1)
+
                     try:
                         # Add the picture to the document and then add a border
                         run.add_picture(file_path, width=Inches(6.5))


### PR DESCRIPTION
Positive Z scores are graphed as a percentage and added 1 pt space before to not have images overlap with table headers.